### PR TITLE
Seamless authentication - encode spaces in URLs before fetching

### DIFF
--- a/src/echolink/library/ess-seamless-lib.php
+++ b/src/echolink/library/ess-seamless-lib.php
@@ -132,7 +132,7 @@ class EchoSystemSeamlessLogin {
         $headers = array();
         $cookie = '';
         while ($redirects >= 0) {
-            curl_setopt($curl, CURLOPT_URL, $url);
+            curl_setopt($curl, CURLOPT_URL, str_replace(' ', '+', $url));
             curl_setopt($curl, CURLOPT_HEADER, true);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             if ($cookie != '') {


### PR DESCRIPTION
If the user has a space in their first (or last?) name, the Location header in the response to the seamless authentication request contains an unescaped space, which then results in a 400 (Bad Request) when the get_headers function attempts to fetch it with curl - which in turn results in an "unexpected response" error being shown to the user in place of the Echo content.

As a quick fix, replacing all spaces with + signs before passing it to curl works around this issue, but it may be better fixed at the ESS end; ESS should ideally return a valid URL (with the space(s) escaped as either + or %20) in the Location: header.  Otherwise, this same issue could potentially affect integrations with other LMSes. 